### PR TITLE
Fix 404 error on mball.co/cv after recent PR merges

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,70 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .tool-versions
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 20.12.1
+      - name: Install CSS/JS dependencies
+        run: npm install
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Fix 404 on mball.co/cv after recent PR merges

Restores `mball.co/cv` by fixing two compounding issues: the site's Jekyll build workflow was deleted and Jekyll was disabled by the CV repo's cross-repo deploy, and the CV deploy itself had no visible failure mode when misconfigured.

## Changes

**`cycomachead/cycomachead.github.io`**
- Restore `.github/workflows/jekyll.yml` — deleted by the previous CV deploy, which stopped GitHub Pages from building entirely
- Remove `.nojekyll` — added by the same deploy, which disabled Jekyll processing

**`cycomachead/cv` — `deploy.yml`**
- Replace `peaceiris/actions-gh-pages` with a surgical `clone → rsync → commit → push` that only touches `cv/` and `michael-ball-cv.pdf`, so it can never clobber `.github/workflows/` or add `.nojekyll` again
- Add a fail-fast preflight check for `CYCOMACHEAD_GH_PAGES_TOKEN` so a missing/invalid token fails loudly instead of silently no-oping
- Update README to document that the PAT no longer needs `Workflows` permission (since the deploy never writes under `.github/`)

## Root cause

`peaceiris/actions-gh-pages` is designed to publish built output to a `gh-pages` branch. When pointed at the Jekyll *source* branch (`main`), it dropped a `.nojekyll` file and its sync removed the site's `jekyll.yml` workflow — so after the CV deployed successfully, GitHub Pages stopped building and `mball.co/cv` 404'd.

## Reviewer notes

- The website fix should be merged/pushed first to restore the live site (the CV bundle is already on `main` from the previous deploy — it just wasn't being built)
- The `deploy.yml` fix must land before any new CV rebuild is triggered, otherwise the old peaceiris config would clobber `jekyll.yml` again
- Confirm GitHub Pages → Settings → Source is still set to **"GitHub Actions"**

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/fCpL99bGjQWN/implementations/cKH7KBW7fqgw) | [Guided Review](https://www.superconductor.com/tickets/fCpL99bGjQWN/implementations/cKH7KBW7fqgw?tab=guided_review)

<!-- created-by-superconductor -->