### PR TITLE
Update CV page content, styling, and mobile navigation improvements

### DIFF
--- a/_layouts/cv.html
+++ b/_layouts/cv.html
@@ -6,7 +6,7 @@
   specific (scoped to .cv-layout) and wins for the CV body/sidebar — and
   finally cv-shell.css, the glue that fits that layout under the shared navbar.
 
-  cv.css / cv-theme.js / cv-sidebar.html are shipped into /cv/ by the
+  cv.css / cv-theme.js / cv-nav.js / cv-sidebar.html are shipped into /cv/ by the
   cycomachead/cv deploy workflow (see that repo's README). The CV is a
   full-bleed 100vh sticky-sidebar layout, so we drop it below the shared
   sticky navbar rather than embedding it in the milo-default page shell.
@@ -45,6 +45,7 @@ Curriculum vitae of {{ site.author.name }}, {{ site.author.employer }}.
   </div>
 
   <script src="{{ '/cv/cv-theme.js' | relative_url }}"></script>
+  <script src="{{ '/cv/cv-nav.js' | relative_url }}"></script>
   <script src="{{ '/assets/js/cv-shell.js' | relative_url }}"></script>
   {% include scripts.html %}
 </body>

--- a/assets/styles/cv-shell.scss
+++ b/assets/styles/cv-shell.scss
@@ -9,18 +9,17 @@
 /* Shield the CV's self-contained design from milo.css's site-wide element
    rules (legacy assets/styles/main.css + Bootstrap Reboot). cv.css already
    scopes everything to .cv-layout, so we only reset the handful of
-   bare-element properties it doesn't set itself — namely the serif heading
-   font + weight and the paragraph text-indent that main.css applies
-   globally. */
+   bare-element properties it doesn't set itself — the heading weight
+   (main.css sets 400 on bare h1–h6) and the paragraph text-indent that
+   main.css applies globally. The heading *font* is not reset here: cv.css
+   sets Source Serif 4 on .cv-content h1–h6, which already outranks
+   main.css's bare-element selector. */
 .cv-layout p,
 .cv-content h1, .cv-content h2, .cv-content h3,
 .cv-content h4, .cv-content h5, .cv-content h6 { text-indent: 0; }
 
 .cv-content h1, .cv-content h2, .cv-content h3,
-.cv-content h4, .cv-content h5, .cv-content h6 {
-  font-family: inherit;
-  font-weight: 700;
-}
+.cv-content h4, .cv-content h5, .cv-content h6 { font-weight: 700; }
 
 .cv-layout img { padding: 0; margin: 0; }
 

--- a/cv/cv-nav.js
+++ b/cv/cv-nav.js
@@ -1,0 +1,133 @@
+// Scroll spy for the sidebar TOC: highlights the section currently being
+// read. The CV is long enough that "where am I?" is a real question, and the
+// TOC is the only navigation on the page.
+//
+// Ships next to cv-theme.js — both are inlined into the standalone preview
+// (`make preview`) and served from /cv/ on the deployed Jekyll site, so this
+// file may not assume anything about the surrounding page beyond the
+// .cv-toc / .cv-sidebar markup the sidebar fragment emits.
+(function () {
+  'use strict';
+
+  var ACTIVE = 'is-active';
+
+  // Resolve a CSS length that may be expressed in px or rem. The site shell
+  // publishes --cv-navbar-h as px from JS but declares a rem fallback, so we
+  // can't just parseFloat it.
+  function toPixels(value) {
+    value = (value || '').trim();
+    if (!value) return 0;
+    var n = parseFloat(value);
+    if (isNaN(n)) return 0;
+    if (/rem$/.test(value)) {
+      return n * parseFloat(getComputedStyle(document.documentElement).fontSize);
+    }
+    return n;
+  }
+
+  function navbarHeight() {
+    return toPixels(getComputedStyle(document.documentElement)
+      .getPropertyValue('--cv-navbar-h'));
+  }
+
+  function init() {
+    var toc = document.querySelector('.cv-toc');
+    if (!toc) return;
+
+    var sidebar = toc.closest('.cv-sidebar');
+    var entries = [];
+
+    toc.querySelectorAll('a[href^="#"]').forEach(function (link) {
+      var id = decodeURIComponent(link.hash.slice(1));
+      var target = id && document.getElementById(id);
+      if (target) entries.push({ link: link, target: target });
+    });
+    if (!entries.length) return;
+
+    var active = null;
+
+    function setActive(entry) {
+      if (entry === active) return;
+      if (active) {
+        active.link.classList.remove(ACTIVE);
+        active.link.removeAttribute('aria-current');
+      }
+      active = entry || null;
+      if (!active) return;
+      active.link.classList.add(ACTIVE);
+      // aria-current is what conveys the highlight to assistive tech — the
+      // colour change alone says nothing.
+      active.link.setAttribute('aria-current', 'true');
+      keepVisible(active.link);
+    }
+
+    // Scroll the sidebar — never the page — so the highlighted link stays on
+    // screen in the desktop layout, where the TOC is taller than its column.
+    function keepVisible(link) {
+      if (!sidebar || sidebar.scrollHeight <= sidebar.clientHeight + 1) return;
+      var l = link.getBoundingClientRect();
+      var s = sidebar.getBoundingClientRect();
+      if (l.top < s.top + 8) sidebar.scrollTop -= (s.top + 8 - l.top);
+      else if (l.bottom > s.bottom - 8) sidebar.scrollTop += (l.bottom - s.bottom + 8);
+    }
+
+    // A heading counts as "current" once it crosses this line, which sits a
+    // little way down the viewport — below the site's sticky navbar, and far
+    // enough in that the section you're actually reading wins over the one
+    // whose last paragraph is still clinging to the top edge.
+    function readingLine() {
+      return navbarHeight() + Math.min(160, window.innerHeight * 0.25);
+    }
+
+    function update() {
+      // The final sections may be too short to ever reach the reading line,
+      // so at the bottom of the page pick the last heading outright —
+      // otherwise the spy sticks several sections back.
+      var scrolled = window.scrollY + window.innerHeight;
+      if (scrolled >= document.documentElement.scrollHeight - 2) {
+        setActive(entries[entries.length - 1]);
+        return;
+      }
+
+      var line = readingLine();
+      var current = entries[0];
+      for (var i = 0; i < entries.length; i++) {
+        if (entries[i].target.getBoundingClientRect().top > line) break;
+        current = entries[i];
+      }
+      setActive(current);
+    }
+
+    var queued = false;
+    function schedule() {
+      if (queued) return;
+      queued = true;
+      window.requestAnimationFrame(function () {
+        queued = false;
+        update();
+      });
+    }
+
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    window.addEventListener('hashchange', schedule);
+    window.addEventListener('load', schedule);
+
+    // Smooth scrolling means the scroll handler wouldn't catch up for a few
+    // hundred milliseconds; highlight the clicked section straight away.
+    toc.addEventListener('click', function (event) {
+      var link = event.target.closest('a[href^="#"]');
+      if (!link) return;
+      var hit = entries.find(function (e) { return e.link === link; });
+      if (hit) setActive(hit);
+    });
+
+    update();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/cv/cv-sidebar.html
+++ b/cv/cv-sidebar.html
@@ -1,12 +1,12 @@
 <aside class="cv-sidebar">
     <a class="cv-skip-link" href="#cv-main">Skip to CV content</a>
 
-  <div class="cv-downloads">
+    <div class="cv-downloads">
     <a class="cv-btn cv-btn-primary" href="/michael-ball-cv.pdf" download>
       Download CV (PDF)
     </a>
-    <a class="cv-btn cv-btn-secondary" href="resume.pdf" download>
-      Download résumé (1 page)
+    <a class="cv-download-alt" href="resume.pdf" download>
+      1-page résumé
     </a>
   </div>
 

--- a/cv/cv.css
+++ b/cv/cv.css
@@ -1,3 +1,9 @@
+/* Headings are set in Source Serif 4. @import has to lead the file — it's
+   only legal before other rules — and it's here rather than in a <link> so
+   the standalone preview (which inlines this file into a <style>) and the
+   deployed site both pick the font up from one place. */
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..700&display=swap');
+
 /* Styling for the rendered CV. Used in two places:
    1. The standalone preview shell (`make preview`) — inlined into cv.html.
    2. The deployed Jekyll site — shipped as cv.css alongside cv-sidebar.html
@@ -21,9 +27,14 @@
   --cv-accent:              var(--cv-berkeley-blue);
   --cv-accent-hover:        var(--cv-berkeley-blue-dark);
   --cv-button-text:         #ffffff;
+  --cv-toc-active-bg:       rgba(0, 38, 118, 0.08);
 
   --cv-content-max:  46rem;
   --cv-sidebar-w:    18rem;
+
+  /* Body copy stays on the system sans stack; headings are Source Serif 4. */
+  --cv-heading-font: "Source Serif 4", "Source Serif Pro", "Source Serif",
+                     Georgia, Cambria, "Times New Roman", Times, serif;
 
   background: var(--cv-bg);
   color:      var(--cv-text);
@@ -45,6 +56,7 @@
   --cv-accent:         var(--cv-berkeley-blue-light);
   --cv-accent-hover:   #a4c2ff;
   --cv-button-text:    #0f1320;
+  --cv-toc-active-bg:  rgba(121, 168, 255, 0.16);
 }
 
 .cv-layout *,
@@ -122,29 +134,44 @@ body:has(> .cv-layout) {
   /* Hide h3 entries in the TOC when the sidebar is collapsed at the top. */
   .cv-sidebar .cv-toc > ol > li > ol { display: none; }
 
-  /* Download buttons side by side instead of stacked. */
-  .cv-downloads { flex-direction: row; }
+  /* Download button and résumé link side by side instead of stacked. */
+  .cv-downloads {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.9rem;
+  }
   .cv-downloads .cv-btn {
-    flex: 1 1 0;
+    flex: 1 1 auto;
     padding: 0.6rem 0.5rem;
     font-size: 0.95rem;
   }
+  .cv-download-alt { align-self: center; flex: 0 0 auto; }
 
-  /* Collapse the section list into wrapping chips so the TOC doesn't push
-     the CV content a full screen down. Padding keeps tap targets big. */
+  /* Wrap the section list into rows so the TOC doesn't push the CV content
+     a full screen down — but as plain text links, not pills. */
   .cv-toc > ol {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.4rem;
+    column-gap: 1.1rem;
+    row-gap: 0.1rem;
   }
   .cv-toc > ol > li { margin: 0; }
   .cv-toc > ol > li > a {
-    display: inline-block;
-    padding: 0.35rem 0.7rem;
-    border: 1px solid var(--cv-rule);
-    border-radius: 999px;
+    padding: 0.35rem 0;
+    border-left: 0;
+    border-radius: 0;
     font-weight: 500;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
+  }
+  /* No left rail to colour in when the links sit in a row — underline the
+     active section instead. */
+  .cv-toc > ol > li > a.is-active,
+  .cv-toc > ol > li:has(a.is-active) > a {
+    background: none;
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.2em;
   }
 
   /* The toggle no longer sits at the bottom of a full-height column. */
@@ -170,10 +197,22 @@ body:has(> .cv-layout) {
   white-space: nowrap;
 }
 
+/* On focus the link is pinned to the viewport rather than laid out inside
+   the sidebar. The sidebar is a `position: sticky` column with
+   `overflow-y: auto`, so an in-flow skip link was clipped by that scroll
+   container (and, on the deployed site, hidden under the sticky navbar).
+   `fixed` + a z-index above Bootstrap's .sticky-top (1020) keeps the whole
+   link on screen. --cv-navbar-h is set by the site shell; the standalone
+   preview has no navbar, hence the 0px fallback. */
 .cv-skip-link:focus {
-  position: static;
+  position: fixed;
+  top: calc(var(--cv-navbar-h, 0px) + 0.5rem);
+  left: 0.75rem;
+  z-index: 1100;
   width: auto;
   height: auto;
+  max-width: calc(100vw - 1.5rem);
+  overflow: visible;
   clip-path: none;
   display: block;
   padding: 0.5rem 0.75rem;
@@ -182,6 +221,7 @@ body:has(> .cv-layout) {
   border-radius: 6px;
   text-decoration: none;
   font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 /* ---------------- Sidebar: download buttons ---------------- */
@@ -189,7 +229,8 @@ body:has(> .cv-layout) {
 .cv-downloads {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  align-items: stretch;
+  gap: 0.4rem;
 }
 
 .cv-btn {
@@ -216,18 +257,20 @@ body:has(> .cv-layout) {
   color: var(--cv-button-text);
 }
 
-.cv-btn-secondary {
-  background: transparent;
-  color: var(--cv-accent);
-  border-color: var(--cv-rule);
-  padding: 0.45rem 0.85rem;
-  font-size: 0.9rem;
+/* Secondary download: a plain text link, not a second button. */
+.cv-download-alt {
+  align-self: center;
+  color: var(--cv-text-muted);
+  font-size: 0.82rem;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  padding: 0.15rem 0.25rem;
 }
 
-.cv-btn-secondary:hover,
-.cv-btn-secondary:focus-visible {
-  border-color: var(--cv-accent);
-  color: var(--cv-accent-hover);
+.cv-download-alt:hover,
+.cv-download-alt:focus-visible {
+  color: var(--cv-accent);
 }
 
 /* ---------------- Sidebar: theme toggle ---------------- */
@@ -290,40 +333,70 @@ body:has(> .cv-layout) {
   margin: 0;
 }
 .cv-toc > ol > li {
-  margin: 0.55rem 0;
+  margin: 0.3rem 0;
 }
 .cv-toc > ol > li > a {
   font-weight: 600;
   color: var(--cv-accent);
 }
 .cv-toc > ol > li > ol {
-  margin: 0.25rem 0 0 0.85rem;
-  padding-left: 0.5rem;
+  margin: 0.15rem 0 0 0.85rem;
   border-left: 1px solid var(--cv-rule);
 }
 .cv-toc > ol > li > ol li {
-  margin: 0.15rem 0;
+  margin: 0.1rem 0;
 }
 .cv-toc > ol > li > ol a {
   color: var(--cv-pacific);
   font-size: 0.88rem;
 }
 
+/* Block links with a left rail: the rail is transparent until the section
+   is the one in view, which is what the scroll spy colours in. */
 .cv-toc a {
+  display: block;
   text-decoration: none;
-  border-bottom: 1px solid transparent;
+  padding: 0.16rem 0.5rem;
+  border-left: 2px solid transparent;
+  border-radius: 0 3px 3px 0;
+  transition: background 120ms ease, border-color 120ms ease;
 }
-.cv-toc a:hover { border-bottom-color: currentColor; }
+.cv-toc a:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+/* ---------------- Sidebar: scroll spy ---------------- */
+/* cv-nav.js adds .is-active (and aria-current="true") to the TOC link for
+   the section currently under the top of the viewport. */
+
+.cv-toc a.is-active {
+  border-left-color: var(--cv-accent);
+  background: var(--cv-toc-active-bg);
+  color: var(--cv-accent);
+  font-weight: 700;
+}
+
+/* An active subsection also lights up the rail of its parent section, so
+   the reader can see where they are at both levels. */
+.cv-toc > ol > li:has(a.is-active) > a { border-left-color: var(--cv-accent); }
 
 /* ---------------- Headings ---------------- */
 
 .cv-content h1,
 .cv-content h2,
-.cv-content h3 {
+.cv-content h3,
+.cv-content h4,
+.cv-content h5,
+.cv-content h6 {
+  font-family: var(--cv-heading-font);
   color: var(--cv-accent);
   line-height: 1.2;
-  /* Breathing room above anchored headings after a TOC jump. */
-  scroll-margin-top: 1rem;
+  /* Breathing room above anchored headings after a TOC jump — and enough of
+     it that the scroll spy agrees a heading you jumped to is "current".
+     On the deployed site the sticky navbar eats the top of the viewport, so
+     add its height too (0 in the standalone preview). */
+  scroll-margin-top: calc(var(--cv-navbar-h, 0px) + 1rem);
 }
 .cv-content h1 {
   font-size: 2.25rem;
@@ -389,6 +462,12 @@ body:has(> .cv-layout) {
   margin: 1.5rem 0 0;
   font-size: 1.05rem;
   color: var(--cv-text);
+}
+
+/* The public CV never lists referees — only this placeholder line. */
+.cv-content .references-note {
+  margin: 0.8rem 0 0;
+  color: var(--cv-text-muted);
 }
 
 /* ---------------- Entry titles ---------------- */

--- a/cv/index.md
+++ b/cv/index.md
@@ -67,18 +67,18 @@ Part-time role focused on Snap<em>!</em> and The Beauty and Joy of Computing pro
 
 ### Course Descriptions
 
-- **CS 10** — _The Beauty and Joy of Computing_ (4 units). Non-majors introduction to computer science. Hands-on, project-based course taught using Snap<em>!</em> and Python.
-- **CS 88 / DATA C88C** — _Computational Structures for Data Science_ (3 units). CS1-or-1.5 course for data science majors, based on Sussman's SICP and taught in Python.
-- **CS 169** — _Engineering Software as a Service_ (4 units). The original software engineering course, later split into CS169A and CS169L.
-- **CS 169A** — _Engineering Software as a Service_ (4 units). Upper-division course on modern software engineering through RESTful design, HTTP, and team projects.
-- **CS 169L** — _Software Engineering Team Project_ (4 units). Follow-up to CS 169A; teams build a semester-long project for a campus organization or local nonprofit.
+- **CS 10** — _The Beauty and Joy of Computing_ (4 units). Non-majors introduction to computer science. Hands-on, project-based course taught using Snap<em>!</em> and Python. [cs10.org](https://cs10.org)
+- **CS 88 / DATA C88C** — _Computational Structures for Data Science_ (3 units). CS1-or-1.5 course for data science majors, based on Sussman's SICP and taught in Python. [c88c.org](https://c88c.org)
+- **CS 169** — _Engineering Software as a Service_ (4 units). The original software engineering course, later split into CS169A and CS169L. [saasbook.info](https://saasbook.info)
+- **CS 169A** — _Engineering Software as a Service_ (4 units). Upper-division course on modern software engineering through RESTful design, HTTP, and team projects. [saasbook.info](https://saasbook.info)
+- **CS 169L** — _Software Engineering Team Project_ (4 units). Follow-up to CS 169A; teams build a semester-long project for a campus organization or local nonprofit. [saasbook.info](https://saasbook.info)
 - **CS W186** — _Introduction to Databases_ (4 units). Upper-division databases course offered in an online format.
 - **CS 194-23** — _Art & Science of Digital Photography_ (4 units). Highly technical photography course bridging art and engineering.
 - **CS 195 / CS H195** — _The Social Implications of Computing Technology_ (1 / 3 units). Course exploring the unintended consequences of computing, including the culture of how we build programs. H195 is an honors course where students complete a small research project.
 - **CS 294-188** — _Design and Evaluation of CS at Scale_ (1 unit). Pedagogy course for teaching assistants on course-course collaborations and current computing-education pedagogy.
 - **CS 302** — _Designing Computer Science Education_ (3 units). Course preparing students to be the instructor of record for a summer CS course.
 - **CS 375** — _Teaching Practicum_ (2 units). First-time CS teaching assistant training.
-- **DATA 101 / CS C187** — _Data Engineering_ (4 units). Upper-division course putting databases into practice. Topics include SQL, window functions, indexing, design, ETL, NoSQL, and graph databases.
+- **DATA 101 / CS C187** — _Data Engineering_ (4 units). Upper-division course putting databases into practice. Topics include SQL, window functions, indexing, design, ETL, NoSQL, and graph databases. [data101.org](https://data101.org)
 
 
 ### Teaching Assignments
@@ -544,31 +544,5 @@ Prior maintainer of Downshift, an open-source React component (~3M weekly NPM do
 
 ## References
 
-**Daniel Garcia**
-Teaching Professor, UC Berkeley EECS
-{:.entry}
-[ddgarcia@cs.berkeley.edu](mailto:ddgarcia@cs.berkeley.edu)
-
-(510) 642-5775
-
-
-**Brian Harvey**
-Teaching Professor Emeritus, UC Berkeley EECS
-{:.entry}
-[bh@cs.berkeley.edu](mailto:bh@cs.berkeley.edu)
-
-(510) 642-8311
-
-
-**Josh Hug**
-Associate Teaching Professor, UC Berkeley EECS
-{:.entry}
-[josh@joshh.ug](mailto:josh@joshh.ug)
-
-
-**Armando Fox**
-Professor, UC Berkeley EECS
-{:.entry}
-[fox@berkeley.edu](mailto:fox@berkeley.edu)
-
-
+References available upon request.
+{:.references-note}


### PR DESCRIPTION
## Update CV page content, styling, and mobile navigation

Addresses several content, accessibility, and UX improvements to the CV page: replaces public referee details with a privacy-friendly placeholder, adds a scroll spy for section tracking, applies Source Serif 4 to headings, de-emphasizes the résumé download link, fixes mobile nav and skip-link bugs, and adds course URLs to teaching descriptions.

## Changes

**Privacy & Content**
- Replace referee names/emails/phones on the public web CV and `public.pdf` with "References available upon request" — real contact details remain in `references.tex` / `data/references.yml` for the private PDF build only
- Add course website URLs after teaching descriptions (cs10.org, c88c.org, saasbook.info, data101.org) in both Markdown and LaTeX outputs

**Navigation & UX**
- Add `cv-nav.js` scroll spy: highlights the active TOC section with a left-rail indicator (desktop) or underline (mobile), sets `aria-current` for screen readers, and auto-scrolls the sidebar to keep the active link visible
- De-emphasize the 1-page résumé link — demoted from a secondary button (`cv-btn-secondary`) to a quiet text link (`.cv-download-alt`) beneath the primary CV download button

**Bug Fixes**
- Fix skip-link clipping: changed from `position: static` (clipped by the sticky/overflow sidebar) to `position: fixed` with `z-index: 1100`, so it's always fully visible on focus on both mobile and desktop
- Fix mobile TOC: replace pill-style links (border + border-radius) with plain wrapping text links; active section underlines instead of using the desktop left-rail style

**Styling**
- Apply Source Serif 4 (via Google Fonts `@import`) to all CV headings via `--cv-heading-font` CSS variable; body copy stays on the system sans stack
- Remove the `font-family: inherit` override in `cv-shell.scss` that was preventing the new heading font from applying

## Visual Changes

- [Desktop scroll spy active state](https://www.superconductor.com/ticket_implementations/bJfwWpcMWwbw/artifacts/G6MpcqfNd6Fz)
- [Mobile scroll spy](https://www.superconductor.com/ticket_implementations/bJfwWpcMWwbw/artifacts/dgdPCkrCMFNT)
- [Skip link visible on desktop](https://www.superconductor.com/ticket_implementations/bJfwWpcMWwbw/artifacts/dLHmtPhpp7Tc)
- [Skip link visible on mobile](https://www.superconductor.com/ticket_implementations/bJfwWpcMWwbw/artifacts/7Bwkw7dL7Q6N)
- [PDF references placeholder](https://www.superconductor.com/ticket_implementations/bJfwWpcMWwbw/artifacts/fwT9qJWhwKQ6)
- [PDF course URLs](https://www.superconductor.com/ticket_implementations/bJfwWpcMWwbw/artifacts/thB6jDPQNFp7)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/Q6MkFFcT9gGW/implementations/bJfwWpcMWwbw) | [Guided Review](https://www.superconductor.com/tickets/Q6MkFFcT9gGW/implementations/bJfwWpcMWwbw?tab=guided_review)

<!-- created-by-superconductor -->