### PR TITLE
Remove hero image border and fix stray div rendering on /about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -21,10 +21,15 @@ I was also fortunate to join Gradescope shortly after graduating, and worked the
 
 —Michael
 
-{%- comment -%}
+{% comment %}
   A <div>, not an <aside>: the sidebar is already a complementary landmark,
   and a second unlabelled one is ambiguous for screen reader users.
-{%- endcomment -%}
+
+  Plain (non-stripping) comment tags on purpose: the whitespace-stripping
+  form swallowed the blank lines around this block, so the div ended up
+  glued to the preceding paragraph and CommonMark escaped it as text.
+{% endcomment %}
+
 <div class="license">
     <a href="https://creativecommons.org/licenses/by-nc-nd/3.0/" rel="license">
         <img alt="Creative Commons Attribution-NonCommercial-NoDerivs 3.0 licence badge"

--- a/assets/scss/_landing.scss
+++ b/assets/scss/_landing.scss
@@ -5,12 +5,18 @@
     text-indent: 0;
   }
 
+  // Full-bleed banner, same as the interior layouts' .hero. The margin and
+  // padding resets undo the blanket `img` rule in main.css, which framed the
+  // banner in a white border and pushed it 1em past the right edge of the
+  // viewport — an em-based gutter that looked very different on a phone.
   &-hero {
     img {
       display: block;
       width: 100%;
       height: 300px;
       object-fit: cover;
+      margin: 0;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
## Fix hero image border and stray `<div>` on /about page

Addresses two visual bugs on the site: removes the white border/overflow around the landing hero image, and fixes a raw `<div>` tag rendering as escaped text on the `/about` page.

## Changes

- **`assets/scss/_landing.scss`** — Add `margin: 0; padding: 0` to `.landing-hero img` to override the blanket `img` rule in `main.css` that was adding a white frame around the banner and causing ~1em horizontal overflow on mobile (the em-based gutter scaled inconsistently across viewport sizes)
- **`about.md`** — Switch from whitespace-stripping `{%- comment -%}` tags to plain `{% comment %}` tags above the license `<div>`. The stripping form was collapsing blank lines, causing the `<div>` to be parsed as part of the preceding paragraph and escaped as literal text by CommonMark

## Visual Changes

**Hero image (desktop):** [Before](https://www.superconductor.com/ticket_implementations/kqrLDfTttd9r/artifacts/gKgtnd9BkcM7) → [After](https://www.superconductor.com/ticket_implementations/kqrLDfTttd9r/artifacts/nrdFwLNTDPGb)

**Hero image (mobile):** [Before](https://www.superconductor.com/ticket_implementations/kqrLDfTttd9r/artifacts/mkC9HbRgq7dr) → [After](https://www.superconductor.com/ticket_implementations/kqrLDfTttd9r/artifacts/7nfJnmBHp78M)

**About page:** [After](https://www.superconductor.com/ticket_implementations/kqrLDfTttd9r/artifacts/QKfCcfDhRD6z)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/CmpRhnz6jLMK/implementations/kqrLDfTttd9r) | [Guided Review](https://www.superconductor.com/tickets/CmpRhnz6jLMK/implementations/kqrLDfTttd9r?tab=guided_review)

<!-- created-by-superconductor -->